### PR TITLE
fixed illusion.py center_crop_resize to handle non-square outputs

### DIFF
--- a/illusion.py
+++ b/illusion.py
@@ -13,17 +13,26 @@ import argparse
 def center_crop_resize(img, output_size=(512, 512)):
     width, height = img.size
 
-    # Calculate dimensions to crop to the center
-    new_dimension = min(width, height)
-    left = (width - new_dimension) / 2
-    top = (height - new_dimension) / 2
-    right = (width + new_dimension) / 2
-    bottom = (height + new_dimension) / 2
+    aspect_orig = width/height;
+    aspect_dest = output_size[0]/output_size[1]
+
+    if(aspect_orig > aspect_dest):
+        # input is too wide, scale based on height and trim left/right
+        new_height = img.height
+        new_width = int(img.height * aspect_dest)
+    else:
+        # input is too tall, scale based on width and trip top/bottom
+        new_width = img.width
+        new_height = int(img.width / aspect_dest)
+
+    left = (width - new_width) / 2
+    top = (height - new_height) / 2
+    right = (width + new_width) / 2
+    bottom = (height + new_height) / 2
 
     # Crop and resize
     img = img.crop((left, top, right, bottom))
     img = img.resize(output_size)
-
     return img
 
 


### PR DESCRIPTION
The example pano_pattern.png that illusion.py uses by default looks like this

![pano_pattern](https://github.com/omerbt/MultiDiffusion/assets/945979/9eb201f0-2e34-4a4e-b9e9-8ac41eead597)

When I ran the script, I got output that didn't match that pattern exactly

![ill_oldbad](https://github.com/omerbt/MultiDiffusion/assets/945979/f98eb59c-969a-462e-8ca3-7ec17a5b22df)

A bit of investigation showed that my output had been based instead on this stretched version of the controlnet image - which it does match:

![crop2](https://github.com/omerbt/MultiDiffusion/assets/945979/3392130d-8d3d-4ba7-a799-abc158b0e189)

Which is what happens if you take a *square* center crop of the original controlnet image:

![crop1](https://github.com/omerbt/MultiDiffusion/assets/945979/11ac7249-d763-448c-a236-e5c04504f09b)

 and then just stretch it to cover the target rectangle. This is what the logic of the `center_crop_resize` seemed to be doing - likely because the upstream code didn't expect to need to handle non-square outputs. I updated this logic to instead take the aspect ratios of the source and destination into account and instead use the largest center crop possible for non-square outputs.

After this change I get output that matches my expectations for the original controlnet image

![ill9](https://github.com/omerbt/MultiDiffusion/assets/945979/bb440280-82e8-47cd-85a8-657372a60a28)

And also tested it on a sideways version of this image and to check that the logic seems to work as planned for tall images too

![ill_tall1](https://github.com/omerbt/MultiDiffusion/assets/945979/e617de31-8095-4dd6-bab7-7f2683ca7417)



